### PR TITLE
Fix for Subnets not in same Vnet

### DIFF
--- a/src/Migrate/custom/Start-AzMigrateTestMigration.ps1
+++ b/src/Migrate/custom/Start-AzMigrateTestMigration.ps1
@@ -117,7 +117,6 @@ function Start-AzMigrateTestMigration {
         $FabricName = $MachineIdArray[10]
         $ProtectionContainerName = $MachineIdArray[12]
         $MachineName = $MachineIdArray[14]
-            
 
         $null = $PSBoundParameters.Add("ResourceGroupName", $ResourceGroupName)
         $null = $PSBoundParameters.Add("ResourceName", $VaultName)
@@ -126,6 +125,42 @@ function Start-AzMigrateTestMigration {
         $null = $PSBoundParameters.Add("ProtectionContainerName", $ProtectionContainerName)
 
         $ReplicationMigrationItem = Az.Migrate.internal\Get-AzMigrateReplicationMigrationItem @PSBoundParameters
+        $AvSetId = $ReplicationMigrationItem.ProviderSpecificDetail.TargetAvailabilitySetId
+        if ($AvSetId)
+        {
+            Import-module -Name Az.Compute
+            Import-module -Name Az.Network
+            $AvSetName = $AvSetId.Split("/")[-1];
+            $AvSetRg = $AvSetId.Split("/")[-5];
+            $AvSet = Get-AzAvailabilitySet -ResourceGroupName $AvSetRg -Name $AvSetName -ErrorVariable notPresent -ErrorAction SilentlyContinue
+            if (!$AvSet)
+            {
+                throw "Availability Set '$($AvSetId)' does not exist."
+            }
+            $VminAvSet = $AvSet.VirtualMachinesReferences[0].Id
+            if ($VminAvSet)
+            {
+                $VmNameinAvSet = $VminAvSet.Split("/")[-1]
+                $VM = Get-AzVM -ResourceGroupName $AvSetRg -Name $VmNameinAvSet -ErrorVariable notPresent -ErrorAction SilentlyContinue
+                if ($VM)
+                {
+                    $NicId = $VM.NetworkProfile.NetworkInterfaces[0].Id
+                    $Nic = Get-Aznetworkinterface -resourceid $NicId -ErrorVariable notPresent -ErrorAction SilentlyContinue
+                    if($Nic -And ($Nic.IpConfigurations) -And ($Nic.IpConfigurations[0].Subnet) -And ($Nic.IpConfigurations[0].Subnet.Id))
+                    {
+                        $Subnet = $Nic.IpConfigurations[0].Subnet.Id.Split("/")
+                        $VnetID = "/$($Subnet[1])/$($Subnet[2])/$($Subnet[3])/$($Subnet[4])/$($Subnet[5])/$($Subnet[6])/$($Subnet[7])/$($Subnet[8])"
+                    }
+                    $TestNetworkID = $TestNetworkID.TrimEnd("/")
+
+                    if ($TestNetworkID -ne $VnetID)
+                    {
+                        throw "Virtual Machines in the availability set '$AvSetName' can only be connected to virtual network '$VnetID'. Change the virtual network selected for the test or update the availability set for the machines, and retry the operation."
+                    }
+                }
+            }
+        }
+
         if ($ReplicationMigrationItem -and ($ReplicationMigrationItem.ProviderSpecificDetail.InstanceType -eq 'VMwarecbt') -and ($ReplicationMigrationItem.AllowedOperation -contains 'TestMigrate' )) {
             $ProviderSpecificDetailInput = [Microsoft.Azure.PowerShell.Cmdlets.Migrate.Models.Api20210210.VMwareCbtTestMigrateInput]::new()
             $ProviderSpecificDetailInput.InstanceType = 'VMwareCbt'


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

<!-- Please add a brief description of the changes made in this PR -->

## Checklist

- [ ] I have read the [_Submitting Changes_](../blob/master/CONTRIBUTING.md#submitting-changes) section of [`CONTRIBUTING.md`](../blob/master/CONTRIBUTING.md)
- [ ] The title of the PR is clear and informative
- [ ] The appropriate `ChangeLog.md` file(s) has been updated:
    - For any service, the `ChangeLog.md` file can be found at `src/{{SERVICE}}/{{SERVICE}}/ChangeLog.md`
    - A snippet outlining the change(s) made in the PR should be written under the `## Upcoming Release` header -- no new version header should be added
- [ ] The PR does not introduce [breaking changes](../blob/master/documentation/breaking-changes/breaking-changes-definition.md)
- [ ] If applicable, the changes made in the PR have proper test coverage
- [ ] For public API changes to cmdlets:
    - [ ] a cmdlet design review was approved for the changes in [this repository](https://github.com/Azure/azure-powershell-cmdlet-review-pr) (_Microsoft internal only_)
        - {Please put the link here}
    - [ ] the markdown help files have been regenerated using the commands listed [here](../blob/master/documentation/development-docs/help-generation.md#updating-all-markdown-files-in-a-module)
